### PR TITLE
Fix 'Deprecated:gensim.models.Word2Vec.load_word2vec_format' with 'ge…

### DIFF
--- a/tree_model/Word2VecFeatureGenerator.py
+++ b/tree_model/Word2VecFeatureGenerator.py
@@ -27,7 +27,7 @@ class Word2VecFeatureGenerator(FeatureGenerator):
         
         # 1). document vector built by multiplying together all the word vectors
         # using Google's pre-trained word vectors
-        model = gensim.models.Word2Vec.load_word2vec_format('GoogleNews-vectors-negative300.bin', binary=True)
+        model = gensim.models.KeyedVectors.load_word2vec_format('GoogleNews-vectors-negative300.bin', binary=True)
         print 'model loaded'
 
         Headline_unigram_array = df['Headline_unigram_vec'].values


### PR DESCRIPTION
While running `tree_model/generateFeatures.py` this DeprecationWarning would arise and interrupt the flow. I've simply changed the call.

```
Traceback (most recent call last):
  File "generateFeatures.py", line 110, in <module>
    process()
  File "generateFeatures.py", line 97, in process
    g.process(data)
  File "/home/lucas/fnc-1/tree_model/Word2VecFeatureGenerator.py", line 30, in process
    model = gensim.models.Word2Vec.load_word2vec_format('GoogleNews-vectors-negative300.bin', binary=True)
  File "/home/lucas/miniconda2/envs/CondaEnv/lib/python2.7/site-packages/gensim/models/word2vec.py", line 954, in load_word2vec_format
    raise DeprecationWarning("Deprecated. Use gensim.models.KeyedVectors.load_word2vec_format instead.")
DeprecationWarning: Deprecated. Use gensim.models.KeyedVectors.load_word2vec_format instead.
```